### PR TITLE
Implement database-backed ecommerce demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ retailbot‑lite/
 ```
 pytest
 ```
+
+## 🛍 Simple Flask store demo
+
+The `ecommerce` folder contains a lightweight shopping cart example powered by
+Flask and SQLite. The database is automatically created on first run with sample
+products and images.
+
+Run it locally:
+
+```bash
+python ecommerce/app.py
+```
+Open http://localhost:5000 to browse the catalog.
 # 🛣️ Roadmap
 
 - Multilingual support (ES, FR, RO)

--- a/ecommerce/app.py
+++ b/ecommerce/app.py
@@ -1,14 +1,47 @@
 from flask import Flask, render_template, redirect, url_for, session, request
+import sqlite3
+from pathlib import Path
 
 app = Flask(__name__)
 app.secret_key = 'super-secret-key'  # In production, use a secure key from env
 
-# Example product catalog
-PRODUCTS = [
-    {'id': 1, 'name': 'Laptop', 'price': 1200.00, 'image': 'https://via.placeholder.com/150'},
-    {'id': 2, 'name': 'Headphones', 'price': 199.99, 'image': 'https://via.placeholder.com/150'},
-    {'id': 3, 'name': 'Smartphone', 'price': 899.50, 'image': 'https://via.placeholder.com/150'},
-]
+DB_PATH = Path(__file__).with_name('products.db')
+
+
+def get_db_connection():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS products (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            price REAL NOT NULL,
+            image TEXT NOT NULL
+        )"""
+    )
+    cur.execute("SELECT COUNT(*) FROM products")
+    if cur.fetchone()[0] == 0:
+        sample_products = [
+            ('Laptop', 1200.00, 'https://via.placeholder.com/150/0000FF/FFFFFF?text=Laptop'),
+            ('Headphones', 199.99, 'https://via.placeholder.com/150/FF0000/FFFFFF?text=Headphones'),
+            ('Smartphone', 899.50, 'https://via.placeholder.com/150/00FF00/FFFFFF?text=Phone'),
+            ('Camera', 499.00, 'https://via.placeholder.com/150/FFFF00/000000?text=Camera'),
+            ('Watch', 249.99, 'https://via.placeholder.com/150/FFA500/FFFFFF?text=Watch'),
+            ('Tablet', 329.00, 'https://via.placeholder.com/150/800080/FFFFFF?text=Tablet')
+        ]
+        cur.executemany(
+            "INSERT INTO products (name, price, image) VALUES (?, ?, ?)",
+            sample_products,
+        )
+    conn.commit()
+    conn.close()
+
 
 
 def get_cart():
@@ -21,9 +54,15 @@ def save_cart(cart):
 
 @app.route('/')
 def index():
+    init_db()
     cart = get_cart()
     cart_count = sum(cart.values())
-    return render_template('index.html', products=PRODUCTS, cart_count=cart_count)
+    conn = get_db_connection()
+    products = conn.execute(
+        "SELECT id, name, price, image FROM products"
+    ).fetchall()
+    conn.close()
+    return render_template('index.html', products=products, cart_count=cart_count)
 
 
 @app.route('/add/<int:product_id>', methods=['POST'])
@@ -39,13 +78,18 @@ def view_cart():
     cart = get_cart()
     items = []
     total = 0
-    for product in PRODUCTS:
-        pid = str(product['id'])
-        quantity = cart.get(pid, 0)
-        if quantity:
-            item_total = product['price'] * quantity
-            items.append({'product': product, 'quantity': quantity, 'total': item_total})
-            total += item_total
+    if cart:
+        conn = get_db_connection()
+        placeholders = ','.join('?' for _ in cart)
+        query = f"SELECT id, name, price, image FROM products WHERE id IN ({placeholders})"
+        products = {str(row['id']): row for row in conn.execute(query, tuple(cart.keys()))}
+        conn.close()
+        for pid, quantity in cart.items():
+            product = products.get(pid)
+            if product:
+                item_total = product['price'] * quantity
+                items.append({'product': product, 'quantity': quantity, 'total': item_total})
+                total += item_total
     return render_template('cart.html', items=items, total=total)
 
 
@@ -56,4 +100,5 @@ def clear_cart():
 
 
 if __name__ == '__main__':
+    init_db()
     app.run(debug=True)

--- a/ecommerce/static/styles.css
+++ b/ecommerce/static/styles.css
@@ -1,12 +1,14 @@
-body {font-family: Arial, sans-serif; margin: 0; padding: 0;}
-header {background-color: #333; color: #fff; padding: 10px;}
-header h1 {display: inline-block; margin: 0; font-size: 1.5em;}
-header nav {float: right;}
-header nav a {color: #fff; margin-left: 10px; text-decoration: none;}
-.products {display: flex; gap: 1em; padding: 1em;}
-.product {border: 1px solid #ccc; padding: 1em; width: 150px; text-align: center;}
-.product img {max-width: 100%;}
-button {padding: 0.5em 1em;}
-table {width: 100%; border-collapse: collapse;}
+body {font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; margin: 0; padding: 0; background-color: #f4f4f4;}
+header {background: linear-gradient(90deg, #4b6cb7, #182848); color: #fff; padding: 15px; box-shadow: 0 2px 4px rgba(0,0,0,0.2);}
+header h1 {display: inline-block; margin: 0; font-size: 1.75em;}
+header nav {float: right; margin-top: 5px;}
+header nav a {color: #fff; margin-left: 15px; text-decoration: none; font-weight: bold;}
+.products {display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 1.5em; padding: 1.5em;}
+.product {border: 1px solid #ccc; padding: 1em; background: #fff; text-align: center; border-radius: 5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);}
+.product img {max-width: 100%; border-radius: 5px;}
+button {padding: 0.5em 1em; border: none; background-color: #4b6cb7; color: #fff; border-radius: 4px; cursor: pointer;}
+button:hover {background-color: #3a529b;}
+table {width: 100%; border-collapse: collapse; background: #fff;}
 th, td {border: 1px solid #ccc; padding: 0.5em; text-align: left;}
 main {padding: 1em;}
+.container {max-width: 960px; margin: 0 auto;}

--- a/ecommerce/templates/base.html
+++ b/ecommerce/templates/base.html
@@ -7,12 +7,14 @@
 </head>
 <body>
     <header>
-        <h1><a href="{{ url_for('index') }}">My Store</a></h1>
-        <nav>
-            <a href="{{ url_for('view_cart') }}">Cart ({{ cart_count }})</a>
-        </nav>
+        <div class="container">
+            <h1><a href="{{ url_for('index') }}">My Store</a></h1>
+            <nav>
+                <a href="{{ url_for('view_cart') }}">Cart ({{ cart_count }})</a>
+            </nav>
+        </div>
     </header>
-    <main>
+    <main class="container">
         {% block content %}{% endblock %}
     </main>
 </body>

--- a/ecommerce/templates/cart.html
+++ b/ecommerce/templates/cart.html
@@ -10,7 +10,7 @@
     </tr>
     {% for item in items %}
     <tr>
-        <td>{{ item.product.name }}</td>
+        <td><img src="{{ item.product.image }}" alt="" width="40"> {{ item.product.name }}</td>
         <td>{{ item.quantity }}</td>
         <td>${{ '%.2f'|format(item.total) }}</td>
     </tr>

--- a/ecommerce/templates/index.html
+++ b/ecommerce/templates/index.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
+<div class="container">
 <h2>Products</h2>
 <div class="products">
     {% for product in products %}
@@ -12,5 +13,6 @@
         </form>
     </div>
     {% endfor %}
+</div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add SQLite-backed product catalog with database init
- improve UI design with gradient header and cards
- display product images in cart
- update README with Flask demo instructions

## Testing
- `python -m py_compile ecommerce/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684afeb6b86c8326ad8eb6f636240c30