### PR TITLE
Add chat feature to demo store

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Run it locally:
 ```bash
 python ecommerce/app.py
 ```
-Open http://localhost:5000 to browse the catalog.
+Open http://localhost:5000 to browse the catalog. The chat interface is
+available at http://localhost:5000/chat.
 # 🛣️ Roadmap
 
 - Multilingual support (ES, FR, RO)

--- a/ecommerce/app.py
+++ b/ecommerce/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, redirect, url_for, session, request
+from retailbot.chatbot import answer_question
 import sqlite3
 from pathlib import Path
 
@@ -97,6 +98,18 @@ def view_cart():
 def clear_cart():
     save_cart({})
     return redirect(url_for('view_cart'))
+
+
+@app.route('/chat', methods=['GET', 'POST'])
+def chat():
+    cart = get_cart()
+    cart_count = sum(cart.values())
+    answer = None
+    if request.method == 'POST':
+        question = request.form.get('question', '')
+        if question:
+            answer = answer_question(question)
+    return render_template('chat.html', cart_count=cart_count, answer=answer)
 
 
 if __name__ == '__main__':

--- a/ecommerce/static/styles.css
+++ b/ecommerce/static/styles.css
@@ -12,3 +12,4 @@ table {width: 100%; border-collapse: collapse; background: #fff;}
 th, td {border: 1px solid #ccc; padding: 0.5em; text-align: left;}
 main {padding: 1em;}
 .container {max-width: 960px; margin: 0 auto;}
+.answer {background:#fff;padding:1em;margin-top:1em;border-radius:5px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}

--- a/ecommerce/templates/base.html
+++ b/ecommerce/templates/base.html
@@ -10,7 +10,9 @@
         <div class="container">
             <h1><a href="{{ url_for('index') }}">My Store</a></h1>
             <nav>
+                <a href="{{ url_for('index') }}">Home</a>
                 <a href="{{ url_for('view_cart') }}">Cart ({{ cart_count }})</a>
+                <a href="{{ url_for('chat') }}">Chat</a>
             </nav>
         </div>
     </header>

--- a/ecommerce/templates/chat.html
+++ b/ecommerce/templates/chat.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Ask RetailBot</h2>
+<form method="post">
+    <textarea name="question" rows="4" style="width:100%" placeholder="Type your question">{{ request.form.question }}</textarea>
+    <button type="submit">Ask</button>
+</form>
+{% if answer %}
+<div class="answer">
+    <h3>Answer</h3>
+    <p>{{ answer }}</p>
+</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- integrate RetailBot with the Flask demo
- add chat page and navigation link
- style chat answer box
- document `/chat` endpoint in README

## Testing
- `python -m py_compile ecommerce/app.py retailbot/chatbot.py`

------
https://chatgpt.com/codex/tasks/task_e_684b05dc0f44832680dfd892789c90ba